### PR TITLE
Added Hamilton and its HSR to Ontario strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -263,8 +263,8 @@ and always knows where you are to not miss where to get off the bus.
 
 	<string name="np_region_canada">Canada</string>
 	<string name="np_name_ontario">Ontario</string>
-	<string name="np_desc_ontario">Ontario, Ottawa, Toronto, Mississauga, Waterloo Region</string>
-	<string name="np_desc_ontario_networks" translatable="false">GO Transit, OC Transpo, Toronto Transit Commission - TTC, MiWay, Grand River Transit - GRT</string>
+	<string name="np_desc_ontario">Ontario, Ottawa, Toronto, Mississauga, Hamilton, Waterloo Region</string>
+	<string name="np_desc_ontario_networks" translatable="false">GO Transit, OC Transpo, Toronto Transit Commission - TTC, MiWay, Hamilton Street Railway - HSR, Grand River Transit - GRT</string>
 	<string name="np_name_quebec">Quebec</string>
 	<string name="np_desc_quebec">Deux-Montagnes, Laval, L\'Assomption, Outaouais, Sud-Ouest, Quebec, Haut-Saint-Laurent, Lanaudière, La Presqu\'Île, Laurentides, Montreal, Les Moulins, Vallée du Richelieu, Chambly-Richelieu-Carignan, Roussillon, Sorel-Varennes, Le Richelain, Sherbrooke, Sainte-Julie</string>
 	<string name="np_desc_quebec_networks" translatable="false">AMT, STM, STL</string>


### PR DESCRIPTION
With my request for adding Hamilton (Ontario) GTFS data to Navitia being granted [1], Transportr now automatically supports this location too. The updated strings maintain geographical order (east to west); feel free to alter this if this is inconsistent somehow.

Address search does not work for Hamilton at this point, only bus stops show up (based on my informal testing), but I understand from issue #559 that this is to be taken up with Navitia as well.

This commit was inspired by commit bf0afb46f37b02c9c7c575b0be9d1d6145fcf28d in merge request #423.

I accept the Contributor License Agreement [2] whenever contributing to Transportr.

[1] https://groups.google.com/forum/#!topic/navitia/mK2TMKqcfjE
[2] https://github.com/grote/Transportr/blob/master/CLA.md